### PR TITLE
Bug fix: change the way we check to see which server we're on (dev or…

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -57,7 +57,7 @@ export function app(): express.Express {
        * put that info in req object
        * server.get('*') below looks for these req attributes
        */
-      let host = req.hostname.indexOf("-bd737") != -1 ? "us-central1-yourvotecounts-bd737.cloudfunctions.net" : "us-central1-yourvotecounts-dev.cloudfunctions.net"
+      let host = req.hostname.indexOf("-dev") != -1 ? "us-central1-yourvotecounts-dev.cloudfunctions.net" : "us-central1-yourvotecounts-bd737.cloudfunctions.net"
       let url = `https://${host}/getVideoInfo?compositionSid=${req.params.compositionSid}`
       let meta = await tiny.get({url}) // https://www.npmjs.com/package/tiny-json-http
       console.log("generateMetaTags():  meta.body.image = \n", meta.body.image)


### PR DESCRIPTION
… prod).  Created a video on prod but the meta tags weren't populated when the video was accessed

using 'headsup.video' but they WERE generated when the video was accessed using the long yourvotecounts-bd737.uc.r.appspot.com domain.  That's because the server.ts:generateMetaTags() was
checking the req.hostname value and the 'if' condition was faulty.  We said: If the url contains -bd737, then we go to the prod firebase function.  Otherwise, we go to the dev firebase
function.  The problem is: When we access the video using the domain 'headsup.video', that domain doesn't contain -bd737 so we were calling the dev firebase function to look up the
page's title and screenshot image.  But of course, that's not where the video was stored.  It was in the prod database.  So now, we basically default to the prod database unless the server/domain
contains -dev